### PR TITLE
Place module in src folder

### DIFF
--- a/src/getbydates.js
+++ b/src/getbydates.js
@@ -97,3 +97,7 @@ const findByDate = async (firstDate, endDate, distance) =>{
     console.log(asteroids);
     return asteroids;
 }
+
+module.exports = {
+    
+}


### PR DESCRIPTION
Move the module into the src folder, to keep public folder for serving static files needed by the client.