### PR TITLE
Ensure dateEnd is after dateStart

### DIFF
--- a/src/getbydates.js
+++ b/src/getbydates.js
@@ -23,7 +23,7 @@ const getRangeOfDates = (firstDate, endDate) => {
     let differenceInDays = (endDate.getTime() - firstDate.getTime()) / (1000 * 3600 * 24);
     
     //Create array of dates to be used
-    if(differenceInDays <= 7){
+    if(differenceInDays <= 7 && differenceInDays >= 0){
 
         while (tempDate <= endDate) {
 
@@ -33,7 +33,7 @@ const getRangeOfDates = (firstDate, endDate) => {
         return dates;
     }
     else{
-        console.log("Date range is greater than 7. Changing to 7 instead")
+        console.log("Date range is out of scope. Changing to 7 instead")
         for(let i = 0; i < 7; i++){
             dates = [...dates, new Date(tempDate).toISOString().split('T')[0]];
             tempDate.setDate(tempDate.getDate() + 1);


### PR DESCRIPTION
If a user inputs a dateEnd variable that is before dateStart, it won't accept it and will instead transition to the default input.
Default input is the max range of dates (7) starting from dateStart.

Resolves #15 